### PR TITLE
Add option for deterministic color based on file path

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,6 +28,12 @@ module.exports = new class Main
       type: "string"
       default: "none"
       enum: ["corner","round","square","none"]
+    colorSelection:
+      title: "Colors"
+      description: "With random, a random color is assigned every time you color a tab. With deterministic, the color is based on the path of the file, so each file has a specific and predictable color."
+      type: "string"
+      default: "random"
+      enum: ["random","deterministic"]
     debug:
       type: "integer"
       default: 0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "atom-simple-logger": "~0.0.1",
-    "season": "^5.3.0"
+    "season": "^5.3.0",
+    "hashbow": "1.1.1"
   },
   "dev-dependencies": {
     "atom-package-reloader": "~0.0.2"


### PR DESCRIPTION
This adds an option to color tabs with a deterministic color. This color is based on the path of a file, and computed using the [hashbow plugin](https://github.com/supercrabtree/hashbow). It is added as an option, so the previous behavior is still supported (and default). I think this also implements #17 btw :)

It was inspired by the [hyperterm-dibdabs](https://www.npmjs.com/package/hyperterm-dibdabs) plugin for hyperterm.