### PR TITLE
 Add option to color new tabs automatically

### DIFF
--- a/lib/color-tabs.coffee
+++ b/lib/color-tabs.coffee
@@ -221,7 +221,11 @@ class ColorTabs
         @processed = processAllTabs()
     unless @disposables?
       @disposables = new CompositeDisposable
-      @disposables.add atom.workspace.onDidAddTextEditor ->
+      @disposables.add atom.workspace.onDidAddTextEditor (event) ->
+        if atom.config.get("color-tabs.autoColor")
+          te = event.textEditor
+          if te?.getPath?
+            processPath te.getPath(), getColorForPath(te.getPath()), false, true
         setTimeout processAllTabs, 10
       @disposables.add atom.workspace.onDidDestroyPaneItem ->
         setTimeout processAllTabs, 10

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -34,6 +34,11 @@ module.exports = new class Main
       type: "string"
       default: "random"
       enum: ["random","deterministic"]
+    autoColor:
+      title: "Color new tabs automatically"
+      description: "If enabled, every new tab you open will automatically be colored."
+      type: 'boolean'
+      default: false
     debug:
       type: "integer"
       default: 0

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,6 +28,12 @@ module.exports = new class Main
       type: "string"
       default: "none"
       enum: ["corner","round","square","none"]
+    colorSelection:
+      title: "Colors"
+      description: "With random, a random color is assigned every time you color a tab. With deterministic, the color is based on the path of the file, so each file has a specific and predictable color."
+      type: "string"
+      default: "random"
+      enum: ["random","deterministic"]
     debug:
       type: "integer"
       default: 0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "atom-simple-logger": "~0.0.1",
-    "season": "^5.3.0"
+    "season": "^5.3.0",
+    "hashbow": "1.1.1"
   },
   "dev-dependencies": {
     "atom-package-reloader": "~0.0.2"


### PR DESCRIPTION
This adds an option to color newly opened tabs automatically. Once a tab is closed and then opened again, a new random color is used. An option is available to enable/disable this, and it is disabled by default.

This PR builds upon #24, but I couldn't find a way to change the base of this PR to that PR, so the diffs include changes of both PRs. Only the [second commit](https://github.com/paulpflug/color-tabs/commit/2be2a4adab9a7ed536d775bb01123197fd27b8bc) is relevant for this PR. I can easily rewrite this PR to work without #24, if that one wouldn't be merged.

This implements #22.